### PR TITLE
temporary ignore on min and max asg instance counts

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -155,7 +155,7 @@ resource "aws_autoscaling_group" "workers" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity, min_size, max_size]
   }
 }
 

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -231,7 +231,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity, min_size, max_size]
   }
 }
 


### PR DESCRIPTION
This will temporarily fix the situation where ASG in us-east-1a have their min count restored to >0
A following PR in infra-kubernetes will make use of this latest patch

Hopefully we won't have to keep this patch for long :/